### PR TITLE
Remove beta version option from version switchers

### DIFF
--- a/src/modules/bookingfrontend/client/src/app/i18n/version-switcher.tsx
+++ b/src/modules/bookingfrontend/client/src/app/i18n/version-switcher.tsx
@@ -20,15 +20,14 @@ const VersionSwitcher: React.FC = () => {
   // Get localized versions
   const versions = [
 		  { key: 'original', label: 'common.original' },
-		  { key: 'new', label: 'common.new' },
-		  { key: 'beta', label: 'bookingfrontend.beta_version' }
+		  { key: 'new', label: 'common.new' }
 	  ];
 
   // Determine current version
   const currentVersion = versionSettings?.version || 'original';
 
   // Handle version change
-  const handleVersionChange = (version: 'original' | 'new' | 'beta') => {
+  const handleVersionChange = (version: 'original' | 'new') => {
     setIsOpen(false);
     setVersion(version);
   };
@@ -75,7 +74,7 @@ const VersionSwitcher: React.FC = () => {
           {versions.map((ver) => (
             <Button
               key={ver.key}
-              onClick={() => handleVersionChange(ver.key as 'original' | 'new' | 'beta')}
+              onClick={() => handleVersionChange(ver.key as 'original' | 'new')}
               variant={currentVersion === ver.key ? "secondary" : "tertiary"}
               style={{
                 width: '200px',

--- a/src/modules/bookingfrontend/client/src/service/api/api-utils.ts
+++ b/src/modules/bookingfrontend/client/src/service/api/api-utils.ts
@@ -255,9 +255,8 @@ export async function fetchInvoices(): Promise<ICompletedReservation[]> {
 
 export interface VersionSettings {
     success: boolean;
-    version: 'original' | 'new' | 'beta';
+    version: 'original' | 'new';
     template_set: string;
-    beta_client: string;
 }
 
 export async function fetchVersionSettings(): Promise<VersionSettings> {
@@ -267,7 +266,7 @@ export async function fetchVersionSettings(): Promise<VersionSettings> {
     return result;
 }
 
-export async function setVersionSettings(version: 'original' | 'new' | 'beta'): Promise<VersionSettings> {
+export async function setVersionSettings(version: 'original' | 'new'): Promise<VersionSettings> {
     const url = phpGWLink(['bookingfrontend', 'version']);
     const response = await fetch(url, {
         method: 'POST',

--- a/src/modules/bookingfrontend/client/src/service/hooks/version-hooks.ts
+++ b/src/modules/bookingfrontend/client/src/service/hooks/version-hooks.ts
@@ -51,20 +51,15 @@ export function useSetVersionSettings() {
   const pathname = usePathname();
 
   return useMutation({
-    mutationFn: (version: 'original' | 'new' | 'beta') => setVersionSettings(version),
+    mutationFn: (version: 'original' | 'new') => setVersionSettings(version),
 
     // When mutation succeeds, update the cache and refetch
     onSuccess: (data) => {
       queryClient.setQueryData(VERSION_SETTINGS_KEY, data);
       queryClient.invalidateQueries({ queryKey: VERSION_SETTINGS_KEY });
 
-      // If switching to a version other than beta, handle special routing
-      if (data.version !== 'beta') {
-        handleRoutingToOldClient(pathname);
-      } else {
-        // Force page reload to apply the new version settings
-        window.location.reload();
-      }
+      // Handle routing to old client for both versions
+      handleRoutingToOldClient(pathname);
     }
   });
 }

--- a/src/modules/bookingfrontend/controllers/VersionController.php
+++ b/src/modules/bookingfrontend/controllers/VersionController.php
@@ -28,7 +28,7 @@ class VersionController
      * @OA\Get(
      *     path="/bookingfrontend/version",
      *     summary="Get current version preference",
-     *     description="Gets the user's current version preference (original, new, or beta)",
+     *     description="Gets the user's current version preference (original or new)",
      *     tags={"Version"},
      *     @OA\Response(
      *         response=200,
@@ -38,7 +38,6 @@ class VersionController
      *             @OA\Property(property="success", type="boolean"),
      *             @OA\Property(property="version", type="string"),
      *             @OA\Property(property="template_set", type="string"),
-     *             @OA\Property(property="beta_client", type="string")
      *         )
      *     )
      * )
@@ -47,32 +46,26 @@ class VersionController
     {
         // Get the current settings from cookies
         $template_set = Sanitizer::get_var('template_set', 'string', 'COOKIE', 'bookingfrontend');
-        $beta_client_raw = Sanitizer::get_var('beta_client', 'raw', 'COOKIE');
-        $beta_client = ($beta_client_raw === 'true');
-        
+
         // Determine version based on cookie values
-        $version = 'original';
-        if ($template_set === 'bookingfrontend_2') {
-            $version = $beta_client ? 'beta' : 'new';
-        }
-        
+        $version = ($template_set === 'bookingfrontend_2') ? 'new' : 'original';
+
         return ResponseHelper::sendErrorResponse(
             [
                 'success' => true,
                 'version' => $version,
                 'template_set' => $template_set,
-                'beta_client' => $beta_client ? 'true' : 'false'
             ],
             200,
             $response
         );
     }
-    
+
     /**
      * @OA\Post(
      *     path="/bookingfrontend/version",
      *     summary="Set version preference",
-     *     description="Sets the user's preferred version (original, new, or beta)",
+     *     description="Sets the user's preferred version (original or new)",
      *     tags={"Version"},
      *     @OA\RequestBody(
      *         required=true,
@@ -81,8 +74,8 @@ class VersionController
      *             @OA\Property(
      *                 property="version",
      *                 type="string",
-     *                 description="The version to set (original, new, or beta)",
-     *                 example="beta"
+     *                 description="The version to set (original or new)",
+     *                 example="new"
      *             )
      *         )
      *     ),
@@ -110,51 +103,45 @@ class VersionController
         // Get the request body as a string and decode it
         $body = $request->getBody()->getContents();
         $data = json_decode($body, true) ?? [];
-        
+
         // Add debugging
         error_log('Version request body: "' . $body . '"');
         error_log('JSON decode result: ' . json_last_error_msg());
         error_log('Parsed data: ' . print_r($data, true));
-        
+
         $version = $data['version'] ?? null;
-        
-        if (!$version || !in_array($version, ['original', 'new', 'beta'])) {
+
+        if (!$version || !in_array($version, ['original', 'new'])) {
             return ResponseHelper::sendErrorResponse(
-                ['error' => 'Invalid version specified. Must be one of: original, new, beta'],
+                ['error' => 'Invalid version specified. Must be one of: original, new'],
                 400
             );
         }
 
         // Get the sessions object for setting cookies
         $sessions = Sessions::getInstance();
-        
-        // Set up template_set and beta_client cookies based on version
+
+        // Set up template_set based on version
         $templateSet = ($version === 'original') ? 'bookingfrontend' : 'bookingfrontend_2';
-        $betaClient = ($version === 'beta') ? 'true' : 'false';
-        
+
         // Log before setting
         error_log('Version value: "' . $version . '"');
-        error_log('Is version equal to "beta"? ' . ($version === 'beta' ? 'true' : 'false'));
-        error_log('Setting beta_client to: "' . $betaClient . '"');
-        
+
         // Set expiration time (1 year from now)
         $expirationTime = time() + (60 * 60 * 24 * 365);
-        
+
         // Use only the Sessions class to set cookies, for consistency with the rest of the application
         $sessions->phpgw_setcookie('template_set', $templateSet, $expirationTime);
-        $sessions->phpgw_setcookie('beta_client', $betaClient, $expirationTime);
 
         // Log the success
         error_log('Setting version to: ' . $version);
         error_log('Template set: ' . $templateSet);
-        error_log('Beta client: ' . $betaClient);
 
         return ResponseHelper::sendErrorResponse(
             [
                 'success' => true,
                 'version' => $version,
                 'template_set' => $templateSet,
-                'beta_client' => $betaClient
             ],
             200,
             $response

--- a/src/modules/bookingfrontend/models/BookingfrontendConfig.php
+++ b/src/modules/bookingfrontend/models/BookingfrontendConfig.php
@@ -35,6 +35,7 @@ class BookingfrontendConfig
 
     /**
      * @OA\Property(type="string")
+	 * @Expose 
      */
     public $develope_mode;
 

--- a/src/modules/phpgwapi/controllers/StartPoint.php
+++ b/src/modules/phpgwapi/controllers/StartPoint.php
@@ -432,46 +432,48 @@ class StartPoint
 		$phpgwapi_common = new \phpgwapi_common();
 
 		$this->validate_object_method();
-		
-		// Check for beta client redirect - ONLY for GET requests and not for JSON returns
+
+		// Check for develop mode redirect - ONLY for GET requests and not for JSON returns
 		if ($app == 'bookingfrontend' && $_SERVER['REQUEST_METHOD'] === 'GET' && Sanitizer::get_var('phpgw_return_as', 'string', 'GET') !== 'json') {
 			$template_set = Sanitizer::get_var('template_set', 'string', 'COOKIE');
-			// Explicitly check for the string "true" since the Sanitizer might not convert it properly
-			$beta_client_raw = Sanitizer::get_var('beta_client', 'raw', 'COOKIE');
-			$beta_client = ($beta_client_raw === 'true');
 			
-			// Handle homepage redirect with no menuaction
-			if ($beta_client && $template_set == 'bookingfrontend_2' && !isset($_GET['menuaction'])) {
-				\phpgw::redirect_link('/bookingfrontend/client/no/');
-			}
-			
-			// Handle redirects with menuaction
-			if ($beta_client && $template_set == 'bookingfrontend_2' && isset($_GET['menuaction'])) {
-				$menuaction = $_GET['menuaction'];
-				$redirectMap = [
-					'bookingfrontend.uibuilding.show' => '/bookingfrontend/client/no/building/%id%',
-					'bookingfrontend.uiresource.show' => '/bookingfrontend/client/no/resource/%id%',
-					// Add more mappings as needed
-				];
-				
-				// Special case for authenticated user pages
-				if ($menuaction === 'bookingfrontend.uiuser.show') {
-					// Check if user is authenticated
-					$bouser = CreateObject('bookingfrontend.bouser');
-					if ($bouser && method_exists($bouser, 'get_user')) {
-						$auth_info = $bouser->get_user();
-						if ($auth_info && isset($auth_info['user_id'])) {
-							\phpgw::redirect_link('/bookingfrontend/client/no/user/details');
+			if ($template_set == 'bookingfrontend_2') {
+				$config_frontend = CreateObject('phpgwapi.config', 'bookingfrontend')->read();
+				$develop_mode = isset($config_frontend['develope_mode']) && $config_frontend['develope_mode'] === 'True';
+
+				// Handle homepage redirect with no menuaction
+				if ($develop_mode && !isset($_GET['menuaction'])) {
+					\phpgw::redirect_link('/bookingfrontend/client/');
+				}
+
+				// Handle redirects with menuaction
+				if ($develop_mode && isset($_GET['menuaction'])) {
+					$menuaction = $_GET['menuaction'];
+					$redirectMap = [
+						'bookingfrontend.uibuilding.show' => '/bookingfrontend/client/no/building/%id%',
+						'bookingfrontend.uiresource.show' => '/bookingfrontend/client/no/resource/%id%',
+						// Add more mappings as needed
+					];
+
+					// Special case for authenticated user pages
+					if ($menuaction === 'bookingfrontend.uiuser.show') {
+						// Check if user is authenticated
+						$bouser = CreateObject('bookingfrontend.bouser');
+						if ($bouser && method_exists($bouser, 'get_user')) {
+							$auth_info = $bouser->get_user();
+							if ($auth_info && isset($auth_info['user_id'])) {
+								\phpgw::redirect_link('/bookingfrontend/client/no/user/details');
+							}
 						}
 					}
-				}
-				
-				foreach ($redirectMap as $action => $redirectUrl) {
-					if (strpos($menuaction, $action) === 0) {
-						// Replace placeholders with actual values
-						if (isset($_GET['id']) && strpos($redirectUrl, '%id%') !== false) {
-							$redirectUrl = str_replace('%id%', $_GET['id'], $redirectUrl);
-							\phpgw::redirect_link($redirectUrl);
+
+					foreach ($redirectMap as $action => $redirectUrl) {
+						if (strpos($menuaction, $action) === 0) {
+							// Replace placeholders with actual values
+							if (isset($_GET['id']) && strpos($redirectUrl, '%id%') !== false) {
+								$redirectUrl = str_replace('%id%', $_GET['id'], $redirectUrl);
+								\phpgw::redirect_link($redirectUrl);
+							}
 						}
 					}
 				}
@@ -486,18 +488,20 @@ class StartPoint
 
 			if ($app == 'bookingfrontend')
 			{
-				// Check for beta client when no menuaction is provided and default to homepage
+				// Check for develop mode when no menuaction is provided and default to homepage
 				if ($_SERVER['REQUEST_METHOD'] === 'GET' && Sanitizer::get_var('phpgw_return_as', 'string', 'GET') !== 'json') {
 					$template_set = Sanitizer::get_var('template_set', 'string', 'COOKIE');
-					// Explicitly check for the string "true" since the Sanitizer might not convert it properly
-					$beta_client_raw = Sanitizer::get_var('beta_client', 'raw', 'COOKIE');
-					$beta_client = ($beta_client_raw === 'true');
 					
-					if ($beta_client && $template_set == 'bookingfrontend_2') {
-						\phpgw::redirect_link('/bookingfrontend/client/no/');
+					if ($template_set == 'bookingfrontend_2') {
+						$config_frontend = CreateObject('phpgwapi.config', 'bookingfrontend')->read();
+						$develop_mode = isset($config_frontend['develope_mode']) && $config_frontend['develope_mode'] === 'True';
+						
+						if ($develop_mode) {
+							\phpgw::redirect_link('/bookingfrontend/client/no/');
+						}
 					}
 				}
-				
+
 				$this->class = 'uisearch';
 			}
 			else if ($app == 'activitycalendarfrontend')

--- a/src/modules/phpgwapi/templates/bookingfrontend/head.inc.php
+++ b/src/modules/phpgwapi/templates/bookingfrontend/head.inc.php
@@ -36,12 +36,12 @@ if (!empty($serverSettings['cache_refresh_token']))
 $config_frontend = CreateObject('phpgwapi.config', 'bookingfrontend')->read();
 $config_backend = CreateObject('phpgwapi.config', 'booking')->read();
 
-$tracker_id		 = !empty($config_frontend['tracker_id']) ? $config_frontend['tracker_id'] : '';
-$tracker_code1	 = <<<JS
+$tracker_id = !empty($config_frontend['tracker_id']) ? $config_frontend['tracker_id'] : '';
+$tracker_code1 = <<<JS
 		var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 		document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 JS;
-$tracker_code2	 = <<<JS
+$tracker_code2 = <<<JS
 		try
 		{
 			var pageTracker = _gat._getTracker("{$tracker_id}");
@@ -69,20 +69,20 @@ $template->set_block('head', 'javascript', 'javascripts');
 $stylesheets = array();
 
 
-$stylesheets[]	 = "/phpgwapi/js/bootstrap/css/bootstrap.min.css";
+$stylesheets[] = "/phpgwapi/js/bootstrap/css/bootstrap.min.css";
 //	$stylesheets[]	 = "/phpgwapi/templates/bookingfrontend/css/fontawesome.all.css";
-$stylesheets[]	 = "/phpgwapi/templates/base/css/fontawesome/css/all.min.css";
+$stylesheets[] = "/phpgwapi/templates/base/css/fontawesome/css/all.min.css";
 
-$stylesheets[]	 = "/phpgwapi/templates/bookingfrontend/css/jquery.autocompleter.css";
-$stylesheets[]	 = "https://fonts.googleapis.com/css?family=Work+Sans";
-$stylesheets[]	 = "/phpgwapi/templates/bookingfrontend/css/custom.css";
-$stylesheets[]	 = "/phpgwapi/templates/bookingfrontend/css/normalize.css";
-$stylesheets[]   = "/phpgwapi/templates/bookingfrontend/css/rubik-font.css";
+$stylesheets[] = "/phpgwapi/templates/bookingfrontend/css/jquery.autocompleter.css";
+$stylesheets[] = "https://fonts.googleapis.com/css?family=Work+Sans";
+$stylesheets[] = "/phpgwapi/templates/bookingfrontend/css/custom.css";
+$stylesheets[] = "/phpgwapi/templates/bookingfrontend/css/normalize.css";
+$stylesheets[] = "/phpgwapi/templates/bookingfrontend/css/rubik-font.css";
 
 if (isset($userSettings['preferences']['common']['theme']))
 {
-	$stylesheets[]	 = "/phpgwapi/templates/bookingfrontend/themes/{$userSettings['preferences']['common']['theme']}.css";
-	$stylesheets[]	 = "/{$app}/templates/bookingfrontend/themes/{$userSettings['preferences']['common']['theme']}.css";
+	$stylesheets[] = "/phpgwapi/templates/bookingfrontend/themes/{$userSettings['preferences']['common']['theme']}.css";
+	$stylesheets[] = "/{$app}/templates/bookingfrontend/themes/{$userSettings['preferences']['common']['theme']}.css";
 }
 
 foreach ($stylesheets as $stylesheet)
@@ -98,8 +98,7 @@ if (!empty($serverSettings['logo_url']))
 {
 	$footerlogoimg = $serverSettings['logo_url'];
 	$template->set_var('footer_logo_img', $footerlogoimg);
-}
-else
+} else
 {
 
 	$footerlogoimg = $webserver_url . "/phpgwapi/templates/bookingfrontend/img/Aktiv-kommune-footer-logo.png";
@@ -116,8 +115,7 @@ if (!empty($serverSettings['bakcground_image']))
 if (!empty($serverSettings['logo_title']))
 {
 	$logo_title = $serverSettings['logo_title'];
-}
-else
+} else
 {
 	$logo_title = 'Logo';
 }
@@ -155,7 +153,7 @@ $template->set_var('SIGNINN', $SIGNINN);
 $executiveofficer = lang('executiveofficer');
 $template->set_var('executiveofficer', $executiveofficer);
 
-$executiveofficer_url = phpgw::link("/", array('menuaction' => 'booking.uiapplication.index'),false, true, true);
+$executiveofficer_url = phpgw::link("/", array('menuaction' => 'booking.uiapplication.index'), false, true, true);
 $template->set_var('executiveofficer_url', $executiveofficer_url);
 
 $municipality = $site_title;
@@ -165,14 +163,12 @@ $template->set_var('municipality', $municipality);
 if (!empty($config_backend['support_address']))
 {
 	$support_email = $config_backend['support_address'];
-}
-else
+} else
 {
 	if (!empty($serverSettings['support_address']))
 	{
 		$support_email = $serverSettings['support_address'];
-	}
-	else
+	} else
 	{
 		$support_email = 'support@aktivkommune.no';
 	}
@@ -189,17 +185,17 @@ if (!empty($config_frontend['url_uustatus']))
 //loads jquery
 phpgwapi_jquery::load_widget('core');
 
-$javascripts	 = array();
-$javascripts[]	 = "/phpgwapi/js/popper/popper.min.js";
-$javascripts[]	 = "/phpgwapi/js/bootstrap/js/bootstrap.min.js";
+$javascripts = array();
+$javascripts[] = "/phpgwapi/js/popper/popper.min.js";
+$javascripts[] = "/phpgwapi/js/bootstrap/js/bootstrap.min.js";
 
-$javascripts[]	 = "/phpgwapi/templates/bookingfrontend/js/knockout-min.js";
-$javascripts[]	 = "/phpgwapi/templates/bookingfrontend/js/knockout.validation.js";
-$javascripts[]	 = "/phpgwapi/templates/bookingfrontend/js/jquery.autocompleter.js";
-$javascripts[]	 = "/phpgwapi/templates/bookingfrontend/js/common.js";
-$javascripts[]	 = "/phpgwapi/templates/bookingfrontend/js/custom.js";
-$javascripts[]	 = "/phpgwapi/templates/bookingfrontend/js/nb-NO.js";
-$javascripts[]	 = "/phpgwapi/js/dateformat/dateformat.js";
+$javascripts[] = "/phpgwapi/templates/bookingfrontend/js/knockout-min.js";
+$javascripts[] = "/phpgwapi/templates/bookingfrontend/js/knockout.validation.js";
+$javascripts[] = "/phpgwapi/templates/bookingfrontend/js/jquery.autocompleter.js";
+$javascripts[] = "/phpgwapi/templates/bookingfrontend/js/common.js";
+$javascripts[] = "/phpgwapi/templates/bookingfrontend/js/custom.js";
+$javascripts[] = "/phpgwapi/templates/bookingfrontend/js/nb-NO.js";
+$javascripts[] = "/phpgwapi/js/dateformat/dateformat.js";
 //	foreach ($javascripts as $javascript)
 //	{
 //		if (file_exists(PHPGW_SERVER_ROOT . $javascript))
@@ -221,14 +217,13 @@ if (!$serverSettings['no_jscombine'])
 		}
 	}
 
-	$cachedir	 = urlencode("{$serverSettings['temp_dir']}/combine_cache");
-	$jsfiles	 = implode(',', $_jsfiles);
+	$cachedir = urlencode("{$serverSettings['temp_dir']}/combine_cache");
+	$jsfiles = implode(',', $_jsfiles);
 	$template->set_var('javascript_uri', "{$webserver_url}/phpgwapi/inc/combine.php?cachedir={$cachedir}&type=javascript&files={$jsfiles}");
 	$template->parse('javascripts', 'javascript', true);
 	unset($jsfiles);
 	unset($_jsfiles);
-}
-else
+} else
 {
 	foreach ($javascripts as $javascript)
 	{
@@ -241,76 +236,68 @@ else
 }
 
 
-$bodoc	 = CreateObject('booking.bodocumentation');
-$manual	 = $bodoc->so->getFrontendDoc();
+$bodoc = CreateObject('booking.bodocumentation');
+$manual = $bodoc->so->getFrontendDoc();
 
-$menuaction	 = Sanitizer::get_var('menuaction', 'GET', 'REQUEST', '');
-$id			 = Sanitizer::get_var('id', 'GET');
+$menuaction = Sanitizer::get_var('menuaction', 'GET', 'REQUEST', '');
+$id = Sanitizer::get_var('id', 'GET');
 if (strpos($menuaction, 'organization'))
 {
-	$boorganization	 = CreateObject('booking.boorganization');
-	$metainfo		 = $boorganization->so->get_metainfo($id);
-	$description	 = preg_replace('/\s+/', ' ', strip_tags(html_entity_decode($metainfo['description_json']['no'])));
-	$keywords		 = $metainfo['name'] . "," . $metainfo['shortname'] . "," . $metainfo['district'] . "," . $metainfo['city'];
-}
-elseif (strpos($menuaction, 'group'))
+	$boorganization = CreateObject('booking.boorganization');
+	$metainfo = $boorganization->so->get_metainfo($id);
+	$description = preg_replace('/\s+/', ' ', strip_tags(html_entity_decode($metainfo['description_json']['no'])));
+	$keywords = $metainfo['name'] . "," . $metainfo['shortname'] . "," . $metainfo['district'] . "," . $metainfo['city'];
+} elseif (strpos($menuaction, 'group'))
 {
-	$bogroup	 = CreateObject('booking.bogroup');
-	$metainfo	 = $bogroup->so->get_metainfo($id);
+	$bogroup = CreateObject('booking.bogroup');
+	$metainfo = $bogroup->so->get_metainfo($id);
 	$description = preg_replace('/\s+/', ' ', strip_tags($metainfo['description']));
-	$keywords	 = $metainfo['name'] . "," . $metainfo['shortname'] . "," . $metainfo['organization'] . "," . $metainfo['district'] . "," . $metainfo['city'];
-}
-elseif (strpos($menuaction, 'building'))
+	$keywords = $metainfo['name'] . "," . $metainfo['shortname'] . "," . $metainfo['organization'] . "," . $metainfo['district'] . "," . $metainfo['city'];
+} elseif (strpos($menuaction, 'building'))
 {
-	$bobuilding	 = CreateObject('booking.bobuilding');
-	$metainfo	 = $bobuilding->so->get_metainfo($id);
+	$bobuilding = CreateObject('booking.bobuilding');
+	$metainfo = $bobuilding->so->get_metainfo($id);
 	$description = preg_replace('/\s+/', ' ', strip_tags(html_entity_decode($metainfo['description_json']['no'])));
-	$keywords	 = $metainfo['name'] . "," . $metainfo['district'] . "," . $metainfo['city'];
-}
-elseif (strpos($menuaction, 'resource'))
+	$keywords = $metainfo['name'] . "," . $metainfo['district'] . "," . $metainfo['city'];
+} elseif (strpos($menuaction, 'resource'))
 {
-	$boresource	 = CreateObject('booking.boresource');
-	$metainfo	 = $boresource->so->get_metainfo($id);
+	$boresource = CreateObject('booking.boresource');
+	$metainfo = $boresource->so->get_metainfo($id);
 	$description = preg_replace('/\s+/', ' ', strip_tags(html_entity_decode($metainfo['description_json']['no'])));
-	$keywords	 = $metainfo['name'] . "," . $metainfo['building'] . "," . $metainfo['district'] . "," . $metainfo['city'];
+	$keywords = $metainfo['name'] . "," . $metainfo['building'] . "," . $metainfo['district'] . "," . $metainfo['city'];
 }
 if ($keywords != '')
 {
 	$keywords = '<meta name="keywords" content="' . htmlspecialchars($keywords) . '">';
-}
-else
+} else
 {
 	$keywords = '<meta name="keywords" content="PorticoEstate">';
 }
 if (!empty($description))
 {
 	$description = '<meta name="description" content="' . htmlspecialchars($description) . '">';
-}
-else
+} else
 {
 	$description = '<meta name="description" content="PorticoEstate">';
 }
 if (!empty($config_frontend['metatag_author']))
 {
 	$author = '<meta name="author" content="' . $config_frontend['metatag_author'] . '">';
-}
-else
+} else
 {
 	$author = '<meta name="author" content="PorticoEstate https://github.com/PorticoEstate/PorticoEstate">';
 }
 if (!empty($config_frontend['metatag_robots']))
 {
 	$robots = '<meta name="robots" content="' . $config_frontend['metatag_robots'] . '">';
-}
-else
+} else
 {
 	$robots = '<meta name="robots" content="none">';
 }
 if (!empty($config_frontend['site_title']))
 {
 	$site_title = $config_frontend['site_title'];
-}
-else
+} else
 {
 	$site_title = $serverSettings['site_title'];
 }
@@ -324,7 +311,7 @@ Cache::session_set('phpgwapi', 'footer_info', $footer_info);
 
 $site_base = $app == 'bookingfrontend' ? "/{$app}/" : '/index.php';
 
-$site_url			= phpgw::link($site_base, array());
+$site_url = phpgw::link($site_base, array());
 $eventsearch_url = phpgw::link('/bookingfrontend/', array('menuaction' => 'bookingfrontend.uieventsearch.show'));
 $placeholder_search = lang('Search');
 $myorgs_text = lang('Show my events');
@@ -337,24 +324,18 @@ $self_uri = $_SERVER['REQUEST_URI'];
 $separator = strpos($self_uri, '?') ? '&' : '?';
 $self_uri = str_replace(array("{$separator}lang=no", "{$separator}lang=en"), '', $self_uri);
 
-// Check for beta client cookie
-$beta_client_raw = Sanitizer::get_var('beta_client', 'raw', 'COOKIE');
-$beta_client = ($beta_client_raw === 'true');
 
 // Initialize all selection states to empty
 $selected_bookingfrontend = '';
 $selected_bookingfrontend_2 = '';
-$beta_selected = '';
 
 // Determine which option should be selected
-if ($userSettings['preferences']['common']['template_set'] === 'bookingfrontend') {
+if ($userSettings['preferences']['common']['template_set'] === 'bookingfrontend')
+{
 	$selected_bookingfrontend = ' selected = "selected"';
-} else if ($userSettings['preferences']['common']['template_set'] === 'bookingfrontend_2') {
-	if ($beta_client) {
-		$beta_selected = ' selected = "selected"';
-	} else {
-		$selected_bookingfrontend_2 = ' selected = "selected"';
-	}
+} else if ($userSettings['preferences']['common']['template_set'] === 'bookingfrontend_2')
+{
+	$selected_bookingfrontend_2 = ' selected = "selected"';
 }
 
 if ($config_frontend['develope_mode'])
@@ -364,12 +345,10 @@ if ($config_frontend['develope_mode'])
 		   <select id = "template_selector" class="btn btn-link btn-sm nav-link dropdown-toggle" style="padding-top: .315rem;-webkit-appearance: none;-moz-appearance: none;">
 			<option class="nav-link" value="bookingfrontend"{$selected_bookingfrontend}>Original</option>
 			<option class="nav-link" value="bookingfrontend_2"{$selected_bookingfrontend_2}>Ny</option>
-			<option class="nav-link" value="beta"{$beta_selected}>Beta</option>
 		   </select>
 		</li>
 HTML;
-}
-else
+} else
 {
 	$template_selector = '';
 }
@@ -404,7 +383,7 @@ $nav = <<<HTML
 					</a>
 				</li>
 				{$template_selector}
-		</ul>		
+		</ul>
 		<div class="event_navbar_container">
 			<div class="arrangement-link-box">
 				<a class="Arrangement_link" href="{$eventsearch_url}">Arrangement</a>
@@ -464,38 +443,36 @@ JS;
 
 
 $tpl_vars = array(
-	'site_title'			 => $site_title,
-	'css'					 => $phpgwapi_common->get_css($cache_refresh_token),
-	'javascript'			 => $phpgwapi_common->get_javascript($cache_refresh_token),
-	'img_icon'				 => $phpgwapi_common->find_image('phpgwapi', 'favicon.ico'),
-	'str_base_url'			 => phpgw::link('/', array(), true, false, true),
-	'dateformat_backend'	 => $userSettings['preferences']['common']['dateformat'],
-	'site_url'				 => phpgw::link($site_base, array()),
-	'eventsearch_url'        => phpgw::link('/bookingfrontend/', array('menuaction' => 'bookingfrontend.uieventsearch.show')),
-	'webserver_url'			 => $webserver_url,
-	'metainfo_author'		 => $author,
-	'userlang'				 => $userlang,
-	'metainfo_keywords'		 => $keywords,
-	'metainfo_description'	 => $description,
-	'metainfo_robots'		 => $robots,
-	'lbl_search'			 => lang('Search'),
-	'logofile'				 => $logofile_frontend,
-	'header_search_class'	 => 'hidden', //(isset($_GET['menuaction']) && $_GET['menuaction'] == 'bookingfrontend.uisearch.index' ? 'hidden' : '')
-	'nav'					 => empty($flags['noframework']) ? $nav : '',
-	'tracker_code'			 => $tracker_matomo_code,
+	'site_title' => $site_title,
+	'css' => $phpgwapi_common->get_css($cache_refresh_token),
+	'javascript' => $phpgwapi_common->get_javascript($cache_refresh_token),
+	'img_icon' => $phpgwapi_common->find_image('phpgwapi', 'favicon.ico'),
+	'str_base_url' => phpgw::link('/', array(), true, false, true),
+	'dateformat_backend' => $userSettings['preferences']['common']['dateformat'],
+	'site_url' => phpgw::link($site_base, array()),
+	'eventsearch_url' => phpgw::link('/bookingfrontend/', array('menuaction' => 'bookingfrontend.uieventsearch.show')),
+	'webserver_url' => $webserver_url,
+	'metainfo_author' => $author,
+	'userlang' => $userlang,
+	'metainfo_keywords' => $keywords,
+	'metainfo_description' => $description,
+	'metainfo_robots' => $robots,
+	'lbl_search' => lang('Search'),
+	'logofile' => $logofile_frontend,
+	'header_search_class' => 'hidden', //(isset($_GET['menuaction']) && $_GET['menuaction'] == 'bookingfrontend.uisearch.index' ? 'hidden' : '')
+	'nav' => empty($flags['noframework']) ? $nav : '',
+	'tracker_code' => $tracker_matomo_code,
 	//		'tracker_image'			 => $tracker_image
 );
 
 
-
-
-$bouser	 = new UserHelper();
+$bouser = new UserHelper();
 
 /**
  * Might be set wrong in the ui-class
  */
 $xslt_app = !empty($flags['xslt_app']) ? true : false;
-$org	 = CreateObject('booking.soorganization');
+$org = CreateObject('booking.soorganization');
 $flags['xslt_app'] = $xslt_app;
 Settings::getInstance()->update('flags', ['xslt_app' => $xslt_app]);
 
@@ -509,11 +486,10 @@ if ($bouser->is_logged_in())
 
 	if ($bouser->orgname == '000000000')
 	{
-		$tpl_vars['login_text_org']	 = lang('SSN not registred');
-		$tpl_vars['login_text']		 = lang('Logout');
-		$tpl_vars['org_url']		 = '#';
-	}
-	else
+		$tpl_vars['login_text_org'] = lang('SSN not registred');
+		$tpl_vars['login_text'] = lang('Logout');
+		$tpl_vars['org_url'] = '#';
+	} else
 	{
 		$org_url = phpgw::link("/{$app}/", array(
 			'menuaction' => 'bookingfrontend.uiorganization.show',
@@ -522,31 +498,29 @@ if ($bouser->is_logged_in())
 
 		$lang_organization = lang('Organization');
 		$tpl_vars['org_info_view'] = "<span><img class='login-logo' src='{$loginlogo}' alt='{$lang_organization}'></img><a href='{$org_url}'>{$bouser->orgname}</a></span>";
-		$tpl_vars['login_text_org']	 = $bouser->orgname;
-		$tpl_vars['login_text']		 = lang('Logout');
+		$tpl_vars['login_text_org'] = $bouser->orgname;
+		$tpl_vars['login_text'] = lang('Logout');
 	}
-	$tpl_vars['login_text']	 = $bouser->orgnr . ' :: ' . lang('Logout');
-	$tpl_vars['login_url']	 = 'logout';
-}
-else if (!empty($user_data['ssn']))
+	$tpl_vars['login_text'] = $bouser->orgnr . ' :: ' . lang('Logout');
+	$tpl_vars['login_url'] = 'logout';
+} else if (!empty($user_data['ssn']))
 {
-	$tpl_vars['login_text_org']	 = '';
-	$tpl_vars['login_text']		 = "{$user_data['first_name']} {$user_data['last_name']} :: " . lang('Logout');
-	$tpl_vars['org_url']		 = '#';
-	$tpl_vars['login_url']	 = 'logout';
-}
-else
+	$tpl_vars['login_text_org'] = '';
+	$tpl_vars['login_text'] = "{$user_data['first_name']} {$user_data['last_name']} :: " . lang('Logout');
+	$tpl_vars['org_url'] = '#';
+	$tpl_vars['login_url'] = 'logout';
+} else
 {
-	$tpl_vars['login_text_org']	 = '';
-	$tpl_vars['org_url']		 = '#';
-	$tpl_vars['login_text']		 = lang('Organization');
-	$tpl_vars['login_url']		 = 'login/?after=' . urlencode($_SERVER['QUERY_STRING']);
-	$login_parameter			 = !empty($config_frontend['login_parameter']) ? $config_frontend['login_parameter'] : '';
-	$custom_login_url			 = !empty($config_frontend['custom_login_url']) ? $config_frontend['custom_login_url'] : '';
+	$tpl_vars['login_text_org'] = '';
+	$tpl_vars['org_url'] = '#';
+	$tpl_vars['login_text'] = lang('Organization');
+	$tpl_vars['login_url'] = 'login/?after=' . urlencode($_SERVER['QUERY_STRING']);
+	$login_parameter = !empty($config_frontend['login_parameter']) ? $config_frontend['login_parameter'] : '';
+	$custom_login_url = !empty($config_frontend['custom_login_url']) ? $config_frontend['custom_login_url'] : '';
 	if ($login_parameter)
 	{
-		$login_parameter		 = ltrim($login_parameter, '&');
-		$tpl_vars['login_url']	 .= "&{$login_parameter}";
+		$login_parameter = ltrim($login_parameter, '&');
+		$tpl_vars['login_url'] .= "&{$login_parameter}";
 		//			$LOGIN  =   $tpl_vars['login_url'];
 	}
 	if ($custom_login_url)
@@ -571,8 +545,8 @@ $template->pfp('out', 'head');
 //	$LOGIN  =   $domain_name;
 //	$LOGIN  = $_SERVER['SERVER_NAME'];
 
-$hostname	 = $_SERVER['SERVER_NAME'];
-$port		 = $_SERVER['SERVER_PORT'];
+$hostname = $_SERVER['SERVER_NAME'];
+$port = $_SERVER['SERVER_PORT'];
 
 $LOGIN = $hostname . ':' . $port;
 

--- a/src/modules/phpgwapi/templates/bookingfrontend_2/head.inc.php
+++ b/src/modules/phpgwapi/templates/bookingfrontend_2/head.inc.php
@@ -309,24 +309,15 @@ $self_uri	 = $_SERVER['REQUEST_URI'];
 $separator	 = strpos($self_uri, '?') ? '&' : '?';
 $self_uri	 = str_replace(array("{$separator}lang=no", "{$separator}lang=en"), '', $self_uri);
 
-// Check for beta client cookie
-$beta_client_raw = Sanitizer::get_var('beta_client', 'raw', 'COOKIE');
-$beta_client = ($beta_client_raw === 'true');
-
 // Initialize all selection states to empty
 $selected_bookingfrontend = '';
 $selected_bookingfrontend_2 = '';
-$beta_selected = '';
 
 // Determine which option should be selected
 if ($userSettings['preferences']['common']['template_set'] === 'bookingfrontend') {
 	$selected_bookingfrontend = ' checked';
 } else if ($userSettings['preferences']['common']['template_set'] === 'bookingfrontend_2') {
-	if ($beta_client) {
-		$beta_selected = ' checked';
-	} else {
-		$selected_bookingfrontend_2 = ' checked';
-	}
+	$selected_bookingfrontend_2 = ' checked';
 }
 $about	 = "https://www.aktiv-kommune.no/";
 $faq	 = "https://www.aktiv-kommune.no/manual/";
@@ -337,7 +328,6 @@ if ($config_frontend['develope_mode'])
 	$version_ingress = lang('which_version_do_you_want');
 	$version_old = lang('old');
 	$version_new = lang('new');
-	$version_beta = lang('beta_version');
 	$template_selector = <<<HTML
               <div>
                 <h3>{$version_title}</h3>
@@ -348,14 +338,9 @@ if ($config_frontend['develope_mode'])
                     {$version_old}
                     <span class="choice__radio"></span>
                   </label>
-                  <label class="choice mb-3">
+                  <label class="choice mb-5">
                     <input type="radio" id="template_bookingfrontend_2" name="select_template" value="bookingfrontend_2" {$selected_bookingfrontend_2} />
                     {$version_new}
-                    <span class="choice__radio"></span>
-                  </label>
-                  <label class="choice mb-5">
-                    <input type="radio" id="template_beta" name="select_template" value="beta" {$beta_selected} />
-                    {$version_beta}
                     <span class="choice__radio"></span>
                   </label>
                 </form>

--- a/src/modules/phpgwapi/templates/bookingfrontend_2/js/custom.js
+++ b/src/modules/phpgwapi/templates/bookingfrontend_2/js/custom.js
@@ -23,8 +23,6 @@ $(document).ready(function ()
 			version = 'original';
 		} else if (selectedTemplate === 'bookingfrontend_2') {
 			version = 'new';
-		} else if (selectedTemplate === 'beta') {
-			version = 'beta';
 		}
 		
 		// Use the new version API
@@ -54,8 +52,6 @@ $(document).ready(function ()
 			version = 'original';
 		} else if (selectedTemplate === 'bookingfrontend_2') {
 			version = 'new';
-		} else if (selectedTemplate === 'beta') {
-			version = 'beta';
 		}
 		
 		// Use the new version API


### PR DESCRIPTION
- Replace beta_client cookie checks with develop_mode config in StartPoint
- Remove beta option from React version switcher component
- Update PHP VersionController to only support original and new versions
- Remove beta radio button from legacy template head
- Update JavaScript version switching logic
- Clean up TypeScript interfaces and function signatures
- Expose develope_mode property in BookingfrontendConfig

This simplifies the version switching system to only support two versions: original (legacy template) and new (modern template). The develop_mode configuration now controls whether version switching is enabled.