### PR TITLE
Fix bookingfrontend routing and template selection

### DIFF
--- a/src/modules/bookingfrontend/routes/Routes.php
+++ b/src/modules/bookingfrontend/routes/Routes.php
@@ -20,6 +20,8 @@ use App\modules\bookingfrontend\helpers\LoginHelper;
 use App\modules\bookingfrontend\helpers\LogoutHelper;
 use App\modules\phpgwapi\controllers\StartPoint;
 use App\modules\phpgwapi\middleware\SessionsMiddleware;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
 use App\modules\bookingfrontend\helpers\UserHelper;
 
@@ -136,6 +138,11 @@ $app->group('/bookingfrontend', function (RouteCollectorProxy $group)
 	$group->get('/invoices', CompletedReservationController::class . ':getReservations');
 })->add(new SessionsMiddleware($app->getContainer()));
 
+
+// Redirect /bookingfrontend to /bookingfrontend/
+$app->get('/bookingfrontend', function (Request $request, Response $response) {
+    return $response->withStatus(301)->withHeader('Location', '/bookingfrontend/');
+});
 
 $app->get('/bookingfrontend/', StartPoint::class . ':bookingfrontend')->add(new SessionsMiddleware($app->getContainer()));
 $app->post('/bookingfrontend/', StartPoint::class . ':bookingfrontend')->add(new SessionsMiddleware($app->getContainer()));

--- a/src/modules/phpgwapi/controllers/StartPoint.php
+++ b/src/modules/phpgwapi/controllers/StartPoint.php
@@ -496,7 +496,12 @@ class StartPoint
 			{
 				// Check for develop mode when no menuaction is provided and default to homepage
 				if ($_SERVER['REQUEST_METHOD'] === 'GET' && Sanitizer::get_var('phpgw_return_as', 'string', 'GET') !== 'json') {
+					// Check cookie first, if unset use the assigned template
 					$template_set = Sanitizer::get_var('template_set', 'string', 'COOKIE');
+					if (empty($template_set)) {
+						$userSettings = Settings::getInstance()->get('user');
+						$template_set = $userSettings['preferences']['common']['template_set'] ?? '';
+					}
 
 					if ($template_set == 'bookingfrontend_2') {
 						$config_frontend = CreateObject('phpgwapi.config', 'bookingfrontend')->read();


### PR DESCRIPTION
- Add redirect from /bookingfrontend to /bookingfrontend/ to prevent 404
- Fix template_set fallback to use user preferences when cookie is empty